### PR TITLE
Slm update to be ruby3 4 and rubygem 4x compatible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 Gemfile.lock
 *.gem
 doc
+.gems

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,9 @@
+v0.4.0 (16th Dec 2025)
+- update mininum Ruby version to 2.5.x
+- remove rdoc - it is incompatible with ruby 3.4.x and rubygem 4.x
+- include BigDecimal as a gem as of ruby 2.5 it is no longer included in the standard library
+- include Matrix as a gem as of ruby 2.6 it is no longer included in the standard library
+
 v0.3.0 (28th April 2013)
 - new rules
 - improved the behaviour of some rules

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,4 +1,6 @@
 v0.4.0 (16th Dec 2025)
+- upgrade rspec to 3.x
+- upgrade rspec syntax to 3.x matchers
 - update mininum Ruby version to 2.5.x
 - remove rdoc - it is incompatible with ruby 3.4.x and rubygem 4.x
 - include BigDecimal as a gem as of ruby 2.5 it is no longer included in the standard library

--- a/lib/preflight/rules/page_count.rb
+++ b/lib/preflight/rules/page_count.rb
@@ -31,7 +31,7 @@ module Preflight
         count = objects.deref(pages[:Count])
 
         case @pattern
-        when Fixnum then check_numeric(count)
+        when Integer then check_numeric(count)
         when Range  then check_range(count)
         when Array  then check_array(count)
         when :even  then check_even(count)

--- a/preflight.gemspec
+++ b/preflight.gemspec
@@ -1,19 +1,23 @@
 Gem::Specification.new do |s|
   s.name              = "preflight"
-  s.version           = "0.3.0"
+  s.version           = "0.4.0"
   s.summary           = "Check PDF files conform to various standards"
   s.description       = "Provides a programatic way to check a PDF file conforms to standards like PDF-X/1a"
   s.license           = "MIT"
   s.author            = "James Healy"
   s.email             = ["james@yob.id.au"]
   s.homepage          = "http://github.com/yob/pdf-preflight"
-  s.has_rdoc          = true
-  s.rdoc_options      << "--title" << "PDF::Preflight" << "--line-numbers"
+  # remove rdoc - it conflicts with ruby 3.4.x and rubygem 4.x
+  # s.has_rdoc          = true
+  # s.rdoc_options      << "--title" << "PDF::Preflight" << "--line-numbers"
   s.files             = Dir.glob("lib/**/*") + Dir.glob("bin/*") + ["README.rdoc", "CHANGELOG"]
   s.executables       << "is_pdfx_1a"
   s.required_rubygems_version = ">=1.3.2"
-  s.required_ruby_version = ">=1.8.7"
+  # as of ruby 2.5 BigDecimal is a gem and no longer in std library
+  s.required_ruby_version = ">=2.5"
 
+  s.add_dependency("bigdecimal")
+  s.add_dependency("matrix")
   s.add_dependency("pdf-reader", ">=1.1.0")
 
   s.add_development_dependency("rake")

--- a/preflight.gemspec
+++ b/preflight.gemspec
@@ -22,6 +22,6 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency("rake")
   s.add_development_dependency("roodi")
-  s.add_development_dependency("rspec",   "~>2.3")
-  s.add_development_dependency("ZenTest", "~>4.4.2")
+  s.add_development_dependency("rspec",   "<4.0")
+  s.add_development_dependency("ZenTest", "<5.0")
 end

--- a/spec/issue_spec.rb
+++ b/spec/issue_spec.rb
@@ -11,23 +11,23 @@ describe Preflight::Issue do
     end
 
     it "should return the description" do
-      issue.description.should == "Transparency detected"
+      expect(issue.description).to eq("Transparency detected")
     end
 
     it "should return the rule as a symbol" do
-      issue.rule.should == :"Preflight::Rules::NoTransparency"
+      expect(issue.rule).to eq(:"Preflight::Rules::NoTransparency")
     end
 
     it "should return the attributes" do
-      issue.attributes.should == {:page => 1}
+      expect(issue.attributes).to eq({:page => 1})
     end
 
     it "should return the attributes via methods" do
-      issue.page.should == 1
+      expect(issue.page).to eq(1)
     end
 
     it "should return true to a respond_to? call" do
-      issue.respond_to?(:page).should be_true
+      expect(issue.respond_to?(:page)).to be(true)
     end
 
   end

--- a/spec/profiles/base_pdfx_spec.rb
+++ b/spec/profiles/base_pdfx_spec.rb
@@ -10,7 +10,7 @@ describe Preflight::Profiles::BasePDFX do
       let(:file_string) { 'pdfx-1a-subsetting' }
 
       it "correctly pass a valid PDF/X-1a file that uses font subsetting" do
-        results.empty?.should be_true
+        expect(results.empty?).to be(true)
       end
     end
 
@@ -18,7 +18,7 @@ describe Preflight::Profiles::BasePDFX do
       let(:file_string) { 'pdfx-1a-no-subsetting' }
 
       it "correctly pass a valid PDF/X-1a file that doesn't use font subsetting" do
-        results.empty?.should be_true
+        expect(results.empty?).to be(true)
       end
     end
 
@@ -26,7 +26,7 @@ describe Preflight::Profiles::BasePDFX do
       let(:file_string) { 'version_1_4' }
 
       it "correctly detect files with an incompatible version" do
-        results.empty?.should_not be_true
+        expect(results.empty?).to be(false)
       end
     end
 
@@ -34,7 +34,7 @@ describe Preflight::Profiles::BasePDFX do
       let(:file_string) { 'encrypted' }
 
       it "correctly detect encrypted files" do
-        results.should eql(["Can't preflight an encrypted PDF"])
+        expect(results).to eql(["Can't preflight an encrypted PDF"])
       end
     end
 
@@ -42,7 +42,7 @@ describe Preflight::Profiles::BasePDFX do
       let(:file_string) { 'encrypted_with_user_pass_apples' }
 
       it "correctly detect encrypted files with a user password" do
-        results.should eql(["Can't preflight an encrypted PDF"])
+        expect(results).to eql(["Can't preflight an encrypted PDF"])
       end
     end
 
@@ -55,7 +55,7 @@ describe Preflight::Profiles::BasePDFX do
 
     context 'without subsettings' do
       it "correctly pass a valid PDF/X-4 file that doesn't use font subsetting" do
-        results.empty?.should be_true
+        expect(results.empty?).to be(true)
       end
     end
   end

--- a/spec/profiles/custom_import_profile_spec.rb
+++ b/spec/profiles/custom_import_profile_spec.rb
@@ -17,7 +17,7 @@ describe "Customised profile that imports the standard PDF/X-1a profile" do
     preflight = CustomImportProfile.new
     messages  = preflight.check(filename)
 
-    messages.empty?.should be_true
+    expect(messages.empty?).to be(true)
   end
 
   it "fail a file that isn't PDF/X-1a compliant" do
@@ -25,7 +25,7 @@ describe "Customised profile that imports the standard PDF/X-1a profile" do
     preflight = CustomImportProfile.new
     messages  = preflight.check(filename)
 
-    messages.empty?.should_not be_true
+    expect(messages.empty?).not_to be(true)
   end
 
   it "fail a file that has a 72ppi image" do
@@ -33,7 +33,7 @@ describe "Customised profile that imports the standard PDF/X-1a profile" do
     preflight = CustomImportProfile.new
     messages  = preflight.check(filename)
 
-    messages.empty?.should_not be_true
+    expect(messages.empty?).not_to be(true)
   end
 
   it "pass a file that has a 300ppi image" do
@@ -41,7 +41,7 @@ describe "Customised profile that imports the standard PDF/X-1a profile" do
     preflight = CustomImportProfile.new
     messages  = preflight.check(filename)
 
-    messages.empty?.should_not be_true
+    expect(messages.empty?).not_to be(true)
   end
 
 end

--- a/spec/profiles/custom_profile_spec.rb
+++ b/spec/profiles/custom_profile_spec.rb
@@ -21,7 +21,7 @@ describe "Customised profile" do
     preflight = CustomProfile.new
     messages  = preflight.check(filename)
 
-    messages.should_not be_empty
+    expect(messages).not_to be_empty
   end
 
   it "pass files with an equal version" do
@@ -29,7 +29,7 @@ describe "Customised profile" do
     preflight = CustomProfile.new
     messages  = preflight.check(filename)
 
-    messages.should be_empty
+    expect(messages).to be_empty
   end
 
   it "fail files with a low ppi" do
@@ -37,7 +37,7 @@ describe "Customised profile" do
     preflight = PpiProfile.new
     messages  = preflight.check(filename)
 
-    messages.should_not be_empty
+    expect(messages).not_to be_empty
   end
 
   it "pass files with high ppi" do
@@ -45,7 +45,7 @@ describe "Customised profile" do
     preflight = PpiProfile.new
     messages  = preflight.check(filename)
 
-    messages.should be_empty
+    expect(messages).to be_empty
   end
 
 end

--- a/spec/profiles/instance_rules_spec.rb
+++ b/spec/profiles/instance_rules_spec.rb
@@ -13,7 +13,7 @@ describe InstanceRuleProfile do
     preflight = InstanceRuleProfile.new
     messages  = preflight.check(filename)
 
-    messages.empty?.should be_true
+    expect(messages.empty?).to be(true)
   end
 
   it "correctly fail a file that doesn't pass a rule added to the profile instance" do
@@ -22,7 +22,7 @@ describe InstanceRuleProfile do
     preflight.rule Preflight::Rules::MaxVersion, 1.3
     messages  = preflight.check(filename)
 
-    messages.empty?.should_not be_true
+    expect(messages.empty?).to be(false)
   end
 
 end

--- a/spec/profiles/invalid_rules_spec.rb
+++ b/spec/profiles/invalid_rules_spec.rb
@@ -13,9 +13,7 @@ describe "Profile with an invalid rule" do
   it "should raise an exception" do
     filename = pdf_spec_file("version_1_4")
     preflight = InvalidProfile.new
-    lambda {
-      preflight.check(filename)
-    }.should raise_error(RuntimeError)
+    expect { preflight.check(filename) }.to raise_error(RuntimeError)
   end
 
 end

--- a/spec/profiles/mutating_rule_arguments_spec.rb
+++ b/spec/profiles/mutating_rule_arguments_spec.rb
@@ -13,9 +13,9 @@ describe "A profile with a rule that mutates it's arguments" do
   it "passes a valid file 2 consequtive times" do
     filename  = pdf_spec_file("version_1_3")
     preflight = MutatingProfile.new
-    preflight.check(filename).should be_empty
+    expect(preflight.check(filename)).to be_empty
 
     preflight = MutatingProfile.new
-    preflight.check(filename).should be_empty
+    expect(preflight.check(filename)).to be_empty
   end
 end

--- a/spec/profiles/pdfa1a_spec.rb
+++ b/spec/profiles/pdfa1a_spec.rb
@@ -7,7 +7,7 @@ describe Preflight::Profiles::PDFA1A do
     preflight = Preflight::Profiles::PDFA1A.new
     messages  = preflight.check(filename)
 
-    messages.empty?.should be_true
+    expect(messages.empty?).to be(true)
   end
 
 end

--- a/spec/profiles/pdfx1a_spec.rb
+++ b/spec/profiles/pdfx1a_spec.rb
@@ -7,7 +7,7 @@ describe Preflight::Profiles::PDFX1A do
     preflight = Preflight::Profiles::PDFX1A.new
     messages  = preflight.check(filename)
 
-    messages.empty?.should be_true
+    expect(messages.empty?).to be(true)
   end
 
   it "correctly pass a valid PDF/X-1a file that doesn't use font subsetting" do
@@ -15,7 +15,7 @@ describe Preflight::Profiles::PDFX1A do
     preflight = Preflight::Profiles::PDFX1A.new
     messages  = preflight.check(filename)
 
-    messages.empty?.should be_true
+    expect(messages.empty?).to be(true)
   end
 
   it "correctly detect files with an incompatible version" do
@@ -23,7 +23,7 @@ describe Preflight::Profiles::PDFX1A do
     preflight = Preflight::Profiles::PDFX1A.new
     messages  = preflight.check(filename)
 
-    messages.empty?.should_not be_true
+    expect(messages.empty?).to be(false)
   end
 
   it "correctly detect encrypted files with a blank user password" do
@@ -31,7 +31,7 @@ describe Preflight::Profiles::PDFX1A do
     preflight = Preflight::Profiles::PDFX1A.new
     messages  = preflight.check(filename)
 
-    messages.should eql(["Can't preflight an encrypted PDF"])
+    expect(messages).to eql(["Can't preflight an encrypted PDF"])
   end
 
   it "correctly detect encrypted files with a user password" do
@@ -39,7 +39,7 @@ describe Preflight::Profiles::PDFX1A do
     preflight = Preflight::Profiles::PDFX1A.new
     messages  = preflight.check(filename)
 
-    messages.should eql(["Can't preflight an encrypted PDF"])
+    expect(messages).to eql(["Can't preflight an encrypted PDF"])
   end
 
   it "should fail files that use object streams"

--- a/spec/rules/box_nesting_spec.rb
+++ b/spec/rules/box_nesting_spec.rb
@@ -8,7 +8,7 @@ describe Preflight::Rules::BoxNesting do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should be_empty
+      expect(rule.issues).to be_empty
     end
   end
 
@@ -18,7 +18,7 @@ describe Preflight::Rules::BoxNesting do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should be_empty
+      expect(rule.issues).to be_empty
     end
   end
 
@@ -28,7 +28,7 @@ describe Preflight::Rules::BoxNesting do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should_not be_empty
+      expect(rule.issues).not_to be_empty
     end
   end
 

--- a/spec/rules/box_presence_spec.rb
+++ b/spec/rules/box_presence_spec.rb
@@ -8,7 +8,7 @@ describe Preflight::Rules::BoxPresence do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should be_empty
+      expect(rule.issues).to be_empty
     end
   end
 
@@ -18,7 +18,7 @@ describe Preflight::Rules::BoxPresence do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should be_empty
+      expect(rule.issues).to be_empty
     end
   end
 
@@ -28,11 +28,11 @@ describe Preflight::Rules::BoxPresence do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should_not be_empty
+      expect(rule.issues).not_to be_empty
       issue = rule.issues[0]
-      issue.rule.should == :"Preflight::Rules::BoxPresence"
-      issue.page.should == 1
-      issue.description.should == "page must have any of ArtBox"
+      expect(issue.rule).to eq(:"Preflight::Rules::BoxPresence")
+      expect(issue.page).to eq(1)
+      expect(issue.description).to eq("page must have any of ArtBox")
     end
 
   end
@@ -43,11 +43,11 @@ describe Preflight::Rules::BoxPresence do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should_not be_empty
+      expect(rule.issues).not_to be_empty
       issue = rule.issues[0]
-      issue.rule.should == :"Preflight::Rules::BoxPresence"
-      issue.page.should == 1
-      issue.description.should == "page must have all of ArtBox, CropBox"
+      expect(issue.rule).to eq(:"Preflight::Rules::BoxPresence")
+      expect(issue.page).to eq(1)
+      expect(issue.description).to eq("page must have all of ArtBox, CropBox")
     end
 
   end

--- a/spec/rules/compression_algorithms_spec.rb
+++ b/spec/rules/compression_algorithms_spec.rb
@@ -7,7 +7,7 @@ describe Preflight::Rules::CompressionAlgorithms do
     ohash    = PDF::Reader::ObjectHash.new(filename)
     chk      = Preflight::Rules::CompressionAlgorithms.new(:FlateDecode)
 
-    chk.check_hash(ohash).should_not be_empty
+    expect(chk.check_hash(ohash)).not_to be_empty
   end
 
   it "correctly pass files without a disallowed compression algorithm" do
@@ -15,7 +15,7 @@ describe Preflight::Rules::CompressionAlgorithms do
     ohash    = PDF::Reader::ObjectHash.new(filename)
     chk      = Preflight::Rules::CompressionAlgorithms.new(:FlateDecode)
 
-    chk.check_hash(ohash).should be_empty
+    expect(chk.check_hash(ohash)).to be_empty
   end
 
 end

--- a/spec/rules/consistent_boxes_spec.rb
+++ b/spec/rules/consistent_boxes_spec.rb
@@ -10,7 +10,7 @@ describe Preflight::Rules::ConsistentBoxes do
       reader.pages.each do |page|
         page.walk(rule)
       end
-      rule.issues.should be_empty
+      expect(rule.issues).to be_empty
     end
   end
 
@@ -22,7 +22,7 @@ describe Preflight::Rules::ConsistentBoxes do
       reader.pages.each do |page|
         page.walk(rule)
       end
-      rule.issues.should_not be_empty
+      expect(rule.issues).not_to be_empty
     end
   end
 
@@ -35,7 +35,7 @@ describe Preflight::Rules::ConsistentBoxes do
       reader.pages.each do |page|
         page.walk(rule)
       end
-      rule.issues.should be_empty
+      expect(rule.issues).to be_empty
     end
   end
 

--- a/spec/rules/cropbox_matches_mediabox_spec.rb
+++ b/spec/rules/cropbox_matches_mediabox_spec.rb
@@ -8,7 +8,7 @@ describe Preflight::Rules::CropboxMatchesMediabox do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should be_empty
+      expect(rule.issues).to be_empty
     end
   end
 
@@ -18,7 +18,7 @@ describe Preflight::Rules::CropboxMatchesMediabox do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should_not be_empty
+      expect(rule.issues).not_to be_empty
     end
   end
 

--- a/spec/rules/document_id_spec.rb
+++ b/spec/rules/document_id_spec.rb
@@ -7,7 +7,7 @@ describe Preflight::Rules::DocumentId do
     ohash    = PDF::Reader::ObjectHash.new(filename)
     chk      = Preflight::Rules::DocumentId.new
 
-    chk.check_hash(ohash).should_not be_empty
+    expect(chk.check_hash(ohash)).not_to be_empty
   end
 
   it "pass files with a document ID in the trailer" do
@@ -15,7 +15,7 @@ describe Preflight::Rules::DocumentId do
     ohash    = PDF::Reader::ObjectHash.new(filename)
     chk      = Preflight::Rules::DocumentId.new
 
-    chk.check_hash(ohash).should be_empty
+    expect(chk.check_hash(ohash)).to be_empty
   end
 
 end

--- a/spec/rules/info_has_keys_spec.rb
+++ b/spec/rules/info_has_keys_spec.rb
@@ -7,7 +7,7 @@ describe Preflight::Rules::InfoHasKeys do
     ohash    = PDF::Reader::ObjectHash.new(filename)
     chk      = Preflight::Rules::InfoHasKeys.new(:Title)
 
-    chk.check_hash(ohash).should_not be_empty
+    expect(chk.check_hash(ohash)).to_not be_empty
   end
 
   it "pass files with a Title entry in the Info dict" do
@@ -15,7 +15,7 @@ describe Preflight::Rules::InfoHasKeys do
     ohash    = PDF::Reader::ObjectHash.new(filename)
     chk      = Preflight::Rules::InfoHasKeys.new(:Title)
 
-    chk.check_hash(ohash).should be_empty
+    expect(chk.check_hash(ohash)).to be_empty
   end
 
 end

--- a/spec/rules/info_specifies_trapping_spec.rb
+++ b/spec/rules/info_specifies_trapping_spec.rb
@@ -7,7 +7,7 @@ describe Preflight::Rules::InfoSpecifiesTrapping do
     ohash    = PDF::Reader::ObjectHash.new(filename)
     chk      = Preflight::Rules::InfoSpecifiesTrapping.new
 
-    chk.check_hash(ohash).should_not be_empty
+    expect(chk.check_hash(ohash)).to_not be_empty
   end
 
   it "pass files with Trapping specified in the Info dict" do
@@ -15,7 +15,7 @@ describe Preflight::Rules::InfoSpecifiesTrapping do
     ohash    = PDF::Reader::ObjectHash.new(filename)
     chk      = Preflight::Rules::InfoSpecifiesTrapping.new
 
-    chk.check_hash(ohash).should be_empty
+    expect(chk.check_hash(ohash)).to be_empty
   end
 
 end

--- a/spec/rules/match_info_entries_spec.rb
+++ b/spec/rules/match_info_entries_spec.rb
@@ -7,7 +7,7 @@ describe Preflight::Rules::MatchInfoEntries do
     ohash    = PDF::Reader::ObjectHash.new(filename)
     chk      = Preflight::Rules::MatchInfoEntries.new(:GTS_PDFXVersion => /PDF\/X/)
 
-    chk.check_hash(ohash).should_not be_empty
+    expect(chk.check_hash(ohash)).to_not be_empty
   end
 
   it "pass files with no GTS_PDFXVersion entry in the Info dict" do
@@ -15,7 +15,7 @@ describe Preflight::Rules::MatchInfoEntries do
     ohash    = PDF::Reader::ObjectHash.new(filename)
     chk      = Preflight::Rules::MatchInfoEntries.new(:GTS_PDFXVersion => /PDF\/X/)
 
-    chk.check_hash(ohash).should be_empty
+    expect(chk.check_hash(ohash)).to be_empty
   end
 
 end

--- a/spec/rules/match_info_pdfx_versions_spec.rb
+++ b/spec/rules/match_info_pdfx_versions_spec.rb
@@ -28,13 +28,13 @@ describe Preflight::Rules::MatchInfoPdfxVersions do
     let(:filename) { pdf_spec_file("no_document_id") }
 
     it "returns an list of errors" do
-      chk.check_hash(ohash).should_not be_empty
+      expect(chk.check_hash(ohash)).to_not be_empty
     end
 
     it "includes format-specific errors" do
       errors = chk.check_hash(ohash)
 
-      errors.each { |error|  error.description[/Invalid file for PDFX_(1a|4)*/].should_not be_empty }
+      errors.each { |error|  expect(error.description[/Invalid file for PDFX_(1a|4)*/]).to_not be_nil }
     end
   end
 
@@ -58,10 +58,12 @@ describe Preflight::Rules::MatchInfoPdfxVersions do
       errors = chk.check_hash(ohash)
 
       pdfx_1a_error = errors.first.description
-      pdfx_4_error  = errors.last.description
+      expect(pdfx_1a_error).to include("Invalid file for PDFX_1a")
+      expect(pdfx_1a_error).to include("max_version: 1.3, current_version: 1.4")
 
-      pdfx_1a_error[/Invalid file for PDFX_1a(.)+max_version=>1\.3(.)+current_version=>1\.4/].should_not be_nil
-      pdfx_4_error[/PDFX_4(.)+invalid(.)+key=>:GTS_PDFXVersion/].should_not be_nil
+      pdfx_4_error  = errors.last.description
+      expect(pdfx_4_error).to include("Invalid file for PDFX_4")
+      expect(pdfx_4_error).to match(/GTS_PDFXVersion/)
     end
   end
 
@@ -69,7 +71,7 @@ describe Preflight::Rules::MatchInfoPdfxVersions do
     let(:filename) { pdf_spec_file("pdfx-1a-subsetting") }
 
     it "succeeds if file is compliant with PDFX-1A version" do
-      chk.check_hash(ohash).should be_empty
+      expect(chk.check_hash(ohash)).to be_empty
     end
   end
 
@@ -77,7 +79,7 @@ describe Preflight::Rules::MatchInfoPdfxVersions do
     let(:filename) { pdf_spec_file("pdfx-4") }
 
     it "succeeds if file is compliant with PDFX-4 version" do
-      chk.check_hash(ohash).should be_empty
+      expect(chk.check_hash(ohash)).to be_empty
     end
   end
 end

--- a/spec/rules/max_ink_density_spec.rb
+++ b/spec/rules/max_ink_density_spec.rb
@@ -8,7 +8,7 @@ describe Preflight::Rules::MaxInkDensity do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should be_empty
+      expect(rule.issues).to be_empty
     end
   end
 
@@ -18,7 +18,7 @@ describe Preflight::Rules::MaxInkDensity do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should be_empty
+      expect(rule.issues).to be_empty
     end
   end
 
@@ -28,7 +28,7 @@ describe Preflight::Rules::MaxInkDensity do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should_not be_empty
+      expect(rule.issues).to_not be_empty
     end
   end
 

--- a/spec/rules/max_version_spec.rb
+++ b/spec/rules/max_version_spec.rb
@@ -7,7 +7,7 @@ describe Preflight::Rules::MaxVersion do
     ohash    = PDF::Reader::ObjectHash.new(filename)
     chk      = Preflight::Rules::MaxVersion.new("1.3")
 
-    chk.check_hash(ohash).should_not be_empty
+    expect(chk.check_hash(ohash)).to_not be_empty
   end
 
   it "correctly pass files with an equal version" do
@@ -15,7 +15,7 @@ describe Preflight::Rules::MaxVersion do
     ohash    = PDF::Reader::ObjectHash.new(filename)
     chk      = Preflight::Rules::MaxVersion.new("1.4")
 
-    chk.check_hash(ohash).should be_empty
+    expect(chk.check_hash(ohash)).to be_empty
   end
 
   it "correctly pass files with a lower version" do
@@ -23,7 +23,7 @@ describe Preflight::Rules::MaxVersion do
     ohash    = PDF::Reader::ObjectHash.new(filename)
     chk      = Preflight::Rules::MaxVersion.new("1.5")
 
-    chk.check_hash(ohash).should be_empty
+    expect(chk.check_hash(ohash)).to be_empty
   end
 
 end

--- a/spec/rules/mediabox_at_origin_spec.rb
+++ b/spec/rules/mediabox_at_origin_spec.rb
@@ -8,7 +8,7 @@ describe Preflight::Rules::MediaboxAtOrigin do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should be_empty
+      expect(rule.issues).to be_empty
     end
   end
 
@@ -18,7 +18,7 @@ describe Preflight::Rules::MediaboxAtOrigin do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should_not be_empty
+      expect(rule.issues).to_not be_empty
     end
   end
 

--- a/spec/rules/min_bleed_spec.rb
+++ b/spec/rules/min_bleed_spec.rb
@@ -10,7 +10,7 @@ describe Preflight::Rules::MinBleed do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should be_empty
+      expect(rule.issues).to be_empty
     end
   end
 
@@ -22,7 +22,7 @@ describe Preflight::Rules::MinBleed do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should be_empty
+      expect(rule.issues).to be_empty
     end
   end
 
@@ -32,7 +32,7 @@ describe Preflight::Rules::MinBleed do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should_not be_empty
+      expect(rule.issues).not_to be_empty
     end
   end
 
@@ -44,7 +44,7 @@ describe Preflight::Rules::MinBleed do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should be_empty
+      expect(rule.issues).to be_empty
     end
   end
 
@@ -56,7 +56,7 @@ describe Preflight::Rules::MinBleed do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should be_empty
+      expect(rule.issues).to be_empty
     end
   end
 
@@ -66,7 +66,7 @@ describe Preflight::Rules::MinBleed do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should_not be_empty
+      expect(rule.issues).not_to be_empty
     end
   end
 

--- a/spec/rules/min_ppi_spec.rb
+++ b/spec/rules/min_ppi_spec.rb
@@ -8,7 +8,7 @@ describe Preflight::Rules::MinPpi do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should be_empty
+      expect(rule.issues).to be_empty
     end
   end
 
@@ -18,7 +18,7 @@ describe Preflight::Rules::MinPpi do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should be_empty
+      expect(rule.issues).to be_empty
     end
   end
 
@@ -28,15 +28,15 @@ describe Preflight::Rules::MinPpi do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should have(1).item
+      expect(rule.issues.size).to eq(1)
 
       issue = rule.issues.first
-      issue.horizontal_ppi.should == 72.0
-      issue.vertical_ppi.should   == 72.0
-      issue.top_left.should       == [36.0, 586.0]
-      issue.bottom_left.should    == [36, 133]
-      issue.bottom_right.should   == [640,133]
-      issue.top_right.should      == [640, 586]
+      expect(issue.horizontal_ppi).to eq(72.0)
+      expect(issue.vertical_ppi).to eq(72.0)
+      expect(issue.top_left).to eq([36.0, 586.0])
+      expect(issue.bottom_left).to eq([36, 133])
+      expect(issue.bottom_right).to eq([640,133])
+      expect(issue.top_right).to eq([640, 586])
     end
   end
 
@@ -46,15 +46,15 @@ describe Preflight::Rules::MinPpi do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.size.should == 1
+      expect(rule.issues.size).to eq(1)
 
       issue = rule.issues.first
-      issue.horizontal_ppi.should == 148.151
-      issue.vertical_ppi.should   == 148.151
-      issue.top_left.should       == [250.24502999999999, 492.52378999999996]
-      issue.bottom_left.should    == [250.24502999999999, 401.64329]
-      issue.bottom_right.should   == [323.14383999999995, 401.64329]
-      issue.top_right.should      == [323.14383999999995, 492.52378999999996]
+      expect(issue.horizontal_ppi).to eq(148.151)
+      expect(issue.vertical_ppi).to eq(148.151)
+      expect(issue.top_left).to eq([250.24502999999999, 492.52378999999996])
+      expect(issue.bottom_left).to eq([250.24502999999999, 401.64329])
+      expect(issue.bottom_right).to eq([323.14383999999995, 401.64329])
+      expect(issue.top_right).to eq([323.14383999999995, 492.52378999999996])
     end
   end
 
@@ -64,7 +64,7 @@ describe Preflight::Rules::MinPpi do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should be_empty
+      expect(rule.issues.size).to eq(0)
     end
   end
 

--- a/spec/rules/no_cmyk_spec.rb
+++ b/spec/rules/no_cmyk_spec.rb
@@ -12,7 +12,7 @@ describe Preflight::Rules::NoCmyk do
         reader.page(1).walk(rule)
       end
 
-      rule.issues.should have(1).item
+      expect(rule.issues.size).to eq(1)
     end
   end
 
@@ -26,7 +26,7 @@ describe Preflight::Rules::NoCmyk do
         reader.page(2).walk(rule)
       end
 
-      rule.issues.should have(1).item
+      expect(rule.issues.size).to eq(1)
     end
   end
 
@@ -40,7 +40,7 @@ describe Preflight::Rules::NoCmyk do
         reader.page(3).walk(rule)
       end
 
-      rule.issues.should have(1).item
+      expect(rule.issues.size).to eq(1)
     end
   end
 
@@ -54,7 +54,7 @@ describe Preflight::Rules::NoCmyk do
         reader.page(4).walk(rule)
       end
 
-      rule.issues.should have(1).item
+      expect(rule.issues.size).to eq(1)
     end
   end
 
@@ -68,7 +68,7 @@ describe Preflight::Rules::NoCmyk do
         reader.page(5).walk(rule)
       end
 
-      rule.issues.should have(1).item
+      expect(rule.issues.size).to eq(1)
     end
   end
 
@@ -82,7 +82,7 @@ describe Preflight::Rules::NoCmyk do
         reader.page(6).walk(rule)
       end
 
-      rule.issues.should have(1).item
+      expect(rule.issues.size).to eq(1)
     end
   end
 
@@ -96,7 +96,7 @@ describe Preflight::Rules::NoCmyk do
         reader.page(7).walk(rule)
       end
 
-      rule.issues.should have(1).item
+      expect(rule.issues.size).to eq(1)
     end
   end
 
@@ -110,7 +110,7 @@ describe Preflight::Rules::NoCmyk do
         reader.page(8).walk(rule)
       end
 
-      rule.issues.should have(1).item
+      expect(rule.issues.size).to eq(1)
     end
   end
 
@@ -124,7 +124,7 @@ describe Preflight::Rules::NoCmyk do
         reader.page(1).walk(rule)
       end
 
-      rule.issues.should be_empty
+      expect(rule.issues.size).to eq(0)
     end
   end
 
@@ -138,7 +138,7 @@ describe Preflight::Rules::NoCmyk do
         reader.page(2).walk(rule)
       end
 
-      rule.issues.should be_empty
+      expect(rule.issues.size).to eq(0)
     end
   end
 
@@ -152,7 +152,7 @@ describe Preflight::Rules::NoCmyk do
         reader.page(3).walk(rule)
       end
 
-      rule.issues.should be_empty
+      expect(rule.issues.size).to eq(0)
     end
   end
 
@@ -166,7 +166,7 @@ describe Preflight::Rules::NoCmyk do
         reader.page(4).walk(rule)
       end
 
-      rule.issues.should be_empty
+      expect(rule.issues.size).to eq(0)
     end
   end
 
@@ -180,7 +180,7 @@ describe Preflight::Rules::NoCmyk do
         reader.page(5).walk(rule)
       end
 
-      rule.issues.should be_empty
+      expect(rule.issues.size).to eq(0)
     end
   end
 
@@ -194,7 +194,7 @@ describe Preflight::Rules::NoCmyk do
         reader.page(6).walk(rule)
       end
 
-      rule.issues.should be_empty
+      expect(rule.issues.size).to eq(0)
     end
   end
 

--- a/spec/rules/no_devicen_spec.rb
+++ b/spec/rules/no_devicen_spec.rb
@@ -12,7 +12,7 @@ describe Preflight::Rules::NoDevicen do
         reader.page(1).walk(rule)
       end
 
-      rule.issues.should have(1).item
+      expect(rule.issues.size).to eq(1)
     end
   end
 
@@ -26,7 +26,7 @@ describe Preflight::Rules::NoDevicen do
         reader.page(2).walk(rule)
       end
 
-      rule.issues.should have(1).item
+      expect(rule.issues.size).to eq(1)
     end
 
     it "should return the colourant names in the issue" do
@@ -37,7 +37,7 @@ describe Preflight::Rules::NoDevicen do
       end
 
       issue = rule.issues.first
-      issue.names.should == [:Orange]
+      expect(issue.names).to eq([:Orange])
     end
   end
 
@@ -51,7 +51,7 @@ describe Preflight::Rules::NoDevicen do
         reader.page(3).walk(rule)
       end
 
-      rule.issues.should have(1).item
+      expect(rule.issues.size).to eq(1)
     end
 
     it "should return the colourant names in the issue" do
@@ -62,7 +62,7 @@ describe Preflight::Rules::NoDevicen do
       end
 
       issue = rule.issues.first
-      issue.names.should == [:Orange]
+      expect(issue.names).to eq([:Orange])
     end
   end
 
@@ -76,7 +76,7 @@ describe Preflight::Rules::NoDevicen do
         reader.page(4).walk(rule)
       end
 
-      rule.issues.should have(1).item
+      expect(rule.issues.size).to eq(1)
     end
 
     it "should return the colourant names in the issue" do
@@ -87,7 +87,7 @@ describe Preflight::Rules::NoDevicen do
       end
 
       issue = rule.issues.first
-      issue.names.should == [:Orange]
+      expect(issue.names).to eq([:Orange])
     end
   end
 
@@ -101,7 +101,7 @@ describe Preflight::Rules::NoDevicen do
         reader.page(5).walk(rule)
       end
 
-      rule.issues.should have(1).item
+      expect(rule.issues.size).to eq(1)
     end
 
     it "should return the colourant names in the issue" do
@@ -112,7 +112,7 @@ describe Preflight::Rules::NoDevicen do
       end
 
       issue = rule.issues.first
-      issue.names.should == [:Orange]
+      expect(issue.names).to eq([:Orange])
     end
   end
 
@@ -126,7 +126,7 @@ describe Preflight::Rules::NoDevicen do
         reader.page(1).walk(rule)
       end
 
-      rule.issues.should be_empty
+      expect(rule.issues.size).to eq(0)
     end
   end
 
@@ -140,7 +140,7 @@ describe Preflight::Rules::NoDevicen do
         reader.page(2).walk(rule)
       end
 
-      rule.issues.should be_empty
+      expect(rule.issues.size).to eq(0)
     end
   end
 
@@ -154,7 +154,7 @@ describe Preflight::Rules::NoDevicen do
         reader.page(3).walk(rule)
       end
 
-      rule.issues.should be_empty
+      expect(rule.issues.size).to eq(0)
     end
   end
 
@@ -168,7 +168,7 @@ describe Preflight::Rules::NoDevicen do
         reader.page(4).walk(rule)
       end
 
-      rule.issues.should be_empty
+      expect(rule.issues.size).to eq(0)
     end
   end
 
@@ -182,7 +182,7 @@ describe Preflight::Rules::NoDevicen do
         reader.page(5).walk(rule)
       end
 
-      rule.issues.should be_empty
+      expect(rule.issues.size).to eq(0)
     end
   end
 
@@ -196,7 +196,7 @@ describe Preflight::Rules::NoDevicen do
         reader.page(6).walk(rule)
       end
 
-      rule.issues.should be_empty
+      expect(rule.issues.size).to eq(0)
     end
   end
 

--- a/spec/rules/no_font_subsets_spec.rb
+++ b/spec/rules/no_font_subsets_spec.rb
@@ -7,7 +7,7 @@ describe Preflight::Rules::NoFontSubsets do
     ohash    = PDF::Reader::ObjectHash.new(filename)
     chk      = Preflight::Rules::NoFontSubsets.new
 
-    chk.check_hash(ohash).should_not be_empty
+    expect(chk.check_hash(ohash)).not_to be_empty
   end
 
   it "pass files with a complete TTF font" do
@@ -15,7 +15,7 @@ describe Preflight::Rules::NoFontSubsets do
     ohash    = PDF::Reader::ObjectHash.new(filename)
     chk      = Preflight::Rules::NoFontSubsets.new
 
-    chk.check_hash(ohash).should be_empty
+    expect(chk.check_hash(ohash)).to be_empty
   end
 
 end

--- a/spec/rules/no_gray_spec.rb
+++ b/spec/rules/no_gray_spec.rb
@@ -12,7 +12,7 @@ describe Preflight::Rules::NoGray do
         reader.page(1).walk(rule)
       end
 
-      rule.issues.should have(1).item
+      expect(rule.issues.size).to eq(1)
     end
   end
 
@@ -26,7 +26,7 @@ describe Preflight::Rules::NoGray do
         reader.page(2).walk(rule)
       end
 
-      rule.issues.should have(1).item
+      expect(rule.issues.size).to eq(1)
     end
   end
 
@@ -40,7 +40,7 @@ describe Preflight::Rules::NoGray do
         reader.page(3).walk(rule)
       end
 
-      rule.issues.should have(1).item
+      expect(rule.issues.size).to eq(1)
     end
   end
 
@@ -54,7 +54,7 @@ describe Preflight::Rules::NoGray do
         reader.page(4).walk(rule)
       end
 
-      rule.issues.should have(1).item
+      expect(rule.issues.size).to eq(1)
     end
   end
 
@@ -68,7 +68,7 @@ describe Preflight::Rules::NoGray do
         reader.page(5).walk(rule)
       end
 
-      rule.issues.should have(1).item
+      expect(rule.issues.size).to eq(1)
     end
   end
 
@@ -82,7 +82,7 @@ describe Preflight::Rules::NoGray do
         reader.page(6).walk(rule)
       end
 
-      rule.issues.should have(1).item
+      expect(rule.issues.size).to eq(1)
     end
   end
 
@@ -96,7 +96,7 @@ describe Preflight::Rules::NoGray do
         reader.page(7).walk(rule)
       end
 
-      rule.issues.should have(1).item
+      expect(rule.issues.size).to eq(1)
     end
   end
 

--- a/spec/rules/no_page_rotation_spec.rb
+++ b/spec/rules/no_page_rotation_spec.rb
@@ -8,7 +8,7 @@ describe Preflight::Rules::NoPageRotation do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should be_empty
+      expect(rule.issues).to be_empty
     end
   end
 
@@ -18,7 +18,7 @@ describe Preflight::Rules::NoPageRotation do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should_not be_empty
+      expect(rule.issues).to_not be_empty
     end
   end
 

--- a/spec/rules/no_private_data_spec.rb
+++ b/spec/rules/no_private_data_spec.rb
@@ -8,7 +8,7 @@ describe Preflight::Rules::NoPrivateData do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should be_empty
+      expect(rule.issues).to be_empty
     end
   end
 
@@ -18,7 +18,7 @@ describe Preflight::Rules::NoPrivateData do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should_not be_empty
+      expect(rule.issues).to_not be_empty
     end
   end
 

--- a/spec/rules/no_registration_black_spec.rb
+++ b/spec/rules/no_registration_black_spec.rb
@@ -12,7 +12,7 @@ describe Preflight::Rules::NoRegistrationBlack do
         reader.page(1).walk(rule)
       end
 
-      rule.issues.should have(1).item
+      expect(rule.issues.size).to eq(1)
     end
   end
 
@@ -26,7 +26,7 @@ describe Preflight::Rules::NoRegistrationBlack do
         reader.page(2).walk(rule)
       end
 
-      rule.issues.should have(1).item
+      expect(rule.issues.size).to eq(1)
     end
   end
 
@@ -40,7 +40,7 @@ describe Preflight::Rules::NoRegistrationBlack do
         reader.page(3).walk(rule)
       end
 
-      rule.issues.should have(1).item
+      expect(rule.issues.size).to eq(1)
     end
   end
 
@@ -54,7 +54,7 @@ describe Preflight::Rules::NoRegistrationBlack do
         reader.page(4).walk(rule)
       end
 
-      rule.issues.should have(1).item
+      expect(rule.issues.size).to eq(1)
     end
   end
 
@@ -68,7 +68,7 @@ describe Preflight::Rules::NoRegistrationBlack do
         reader.page(1).walk(rule)
       end
 
-      rule.issues.should be_empty
+      expect(rule.issues.size).to eq(0)
     end
   end
 
@@ -82,7 +82,7 @@ describe Preflight::Rules::NoRegistrationBlack do
         reader.page(2).walk(rule)
       end
 
-      rule.issues.should be_empty
+      expect(rule.issues.size).to eq(0)
     end
   end
 
@@ -96,7 +96,7 @@ describe Preflight::Rules::NoRegistrationBlack do
         reader.page(6).walk(rule)
       end
 
-      rule.issues.should be_empty
+      expect(rule.issues.size).to eq(0)
     end
   end
 
@@ -110,7 +110,7 @@ describe Preflight::Rules::NoRegistrationBlack do
         reader.page(1).walk(rule)
       end
 
-      rule.issues.should be_empty
+      expect(rule.issues.size).to eq(0)
     end
   end
 
@@ -124,7 +124,7 @@ describe Preflight::Rules::NoRegistrationBlack do
         reader.page(2).walk(rule)
       end
 
-      rule.issues.should be_empty
+      expect(rule.issues.size).to eq(0)
     end
   end
 
@@ -138,7 +138,7 @@ describe Preflight::Rules::NoRegistrationBlack do
         reader.page(3).walk(rule)
       end
 
-      rule.issues.should be_empty
+      expect(rule.issues.size).to eq(0)
     end
   end
 
@@ -152,7 +152,7 @@ describe Preflight::Rules::NoRegistrationBlack do
         reader.page(4).walk(rule)
       end
 
-      rule.issues.should be_empty
+      expect(rule.issues.size).to eq(0)
     end
   end
 
@@ -166,7 +166,7 @@ describe Preflight::Rules::NoRegistrationBlack do
         reader.page(5).walk(rule)
       end
 
-      rule.issues.should be_empty
+      expect(rule.issues.size).to eq(0)
     end
   end
 
@@ -180,7 +180,7 @@ describe Preflight::Rules::NoRegistrationBlack do
         reader.page(6).walk(rule)
       end
 
-      rule.issues.should be_empty
+      expect(rule.issues.size).to eq(0)
     end
   end
 end

--- a/spec/rules/no_rgb_spec.rb
+++ b/spec/rules/no_rgb_spec.rb
@@ -12,7 +12,7 @@ describe Preflight::Rules::NoRgb do
         reader.page(1).walk(rule)
       end
 
-      rule.issues.should have(1).item
+      expect(rule.issues.size).to eq(1)
     end
   end
 
@@ -26,7 +26,7 @@ describe Preflight::Rules::NoRgb do
         reader.page(2).walk(rule)
       end
 
-      rule.issues.should have(1).item
+      expect(rule.issues.size).to eq(1)
     end
   end
 
@@ -40,7 +40,7 @@ describe Preflight::Rules::NoRgb do
         reader.page(3).walk(rule)
       end
 
-      rule.issues.should have(1).item
+      expect(rule.issues.size).to eq(1)
     end
   end
 
@@ -54,7 +54,7 @@ describe Preflight::Rules::NoRgb do
         reader.page(4).walk(rule)
       end
 
-      rule.issues.should have(1).item
+      expect(rule.issues.size).to eq(1)
     end
   end
 
@@ -68,7 +68,7 @@ describe Preflight::Rules::NoRgb do
         reader.page(5).walk(rule)
       end
 
-      rule.issues.should have(1).item
+      expect(rule.issues.size).to eq(1)
     end
   end
 
@@ -82,7 +82,7 @@ describe Preflight::Rules::NoRgb do
         reader.page(6).walk(rule)
       end
 
-      rule.issues.should have(1).item
+      expect(rule.issues.size).to eq(1)
     end
   end
 
@@ -96,7 +96,7 @@ describe Preflight::Rules::NoRgb do
         reader.page(7).walk(rule)
       end
 
-      rule.issues.should have(1).item
+      expect(rule.issues.size).to eq(1)
     end
   end
 
@@ -110,7 +110,7 @@ describe Preflight::Rules::NoRgb do
         reader.page(8).walk(rule)
       end
 
-      rule.issues.should have(1).item
+      expect(rule.issues.size).to eq(1)
     end
   end
 
@@ -124,7 +124,7 @@ describe Preflight::Rules::NoRgb do
         reader.page(1).walk(rule)
       end
 
-      rule.issues.should be_empty
+      expect(rule.issues.size).to eq(0)
     end
   end
 
@@ -138,7 +138,7 @@ describe Preflight::Rules::NoRgb do
         reader.page(2).walk(rule)
       end
 
-      rule.issues.should be_empty
+      expect(rule.issues.size).to eq(0)
     end
   end
 
@@ -152,7 +152,7 @@ describe Preflight::Rules::NoRgb do
         reader.page(3).walk(rule)
       end
 
-      rule.issues.should be_empty
+      expect(rule.issues.size).to eq(0)
     end
   end
 
@@ -166,7 +166,7 @@ describe Preflight::Rules::NoRgb do
         reader.page(4).walk(rule)
       end
 
-      rule.issues.should be_empty
+      expect(rule.issues.size).to eq(0)
     end
   end
 
@@ -180,7 +180,7 @@ describe Preflight::Rules::NoRgb do
         reader.page(5).walk(rule)
       end
 
-      rule.issues.should be_empty
+      expect(rule.issues.size).to eq(0)
     end
   end
 
@@ -194,7 +194,7 @@ describe Preflight::Rules::NoRgb do
         reader.page(6).walk(rule)
       end
 
-      rule.issues.should be_empty
+      expect(rule.issues.size).to eq(0)
     end
   end
 

--- a/spec/rules/no_separation_spec.rb
+++ b/spec/rules/no_separation_spec.rb
@@ -12,7 +12,7 @@ describe Preflight::Rules::NoSeparation do
         reader.page(1).walk(rule)
       end
 
-      rule.issues.should have(1).item
+      expect(rule.issues.size).to eq(1)
     end
   end
 
@@ -26,7 +26,7 @@ describe Preflight::Rules::NoSeparation do
         reader.page(2).walk(rule)
       end
 
-      rule.issues.should have(1).item
+      expect(rule.issues.size).to eq(1)
     end
 
     it "should return the separation name in the issue" do
@@ -37,7 +37,7 @@ describe Preflight::Rules::NoSeparation do
       end
 
       issue = rule.issues.first
-      issue.name.should == :"PANTONE 1788 M"
+      expect(issue.name).to eq(:"PANTONE 1788 M")
     end
   end
 
@@ -51,7 +51,7 @@ describe Preflight::Rules::NoSeparation do
         reader.page(3).walk(rule)
       end
 
-      rule.issues.should have(1).item
+      expect(rule.issues.size).to eq(1)
     end
 
     it "should return the separation name in the issue" do
@@ -62,7 +62,7 @@ describe Preflight::Rules::NoSeparation do
       end
 
       issue = rule.issues.first
-      issue.name.should == :Orange
+      expect(issue.name).to eq(:Orange)
     end
   end
 
@@ -76,7 +76,7 @@ describe Preflight::Rules::NoSeparation do
         reader.page(4).walk(rule)
       end
 
-      rule.issues.should have(1).item
+      expect(rule.issues.size).to eq(1)
     end
 
     it "should return the separation name in the issue" do
@@ -87,7 +87,7 @@ describe Preflight::Rules::NoSeparation do
       end
 
       issue = rule.issues.first
-      issue.name.should == :Orange
+      expect(issue.name).to eq(:Orange)
     end
   end
 
@@ -101,7 +101,7 @@ describe Preflight::Rules::NoSeparation do
         reader.page(5).walk(rule)
       end
 
-      rule.issues.should have(1).item
+      expect(rule.issues.size).to eq(1)
     end
 
     it "should return the separation name in the issue" do
@@ -112,7 +112,7 @@ describe Preflight::Rules::NoSeparation do
       end
 
       issue = rule.issues.first
-      issue.name.should == :Yellow
+      expect(issue.name).to eq(:Yellow)
     end
   end
 
@@ -126,7 +126,7 @@ describe Preflight::Rules::NoSeparation do
         reader.page(1).walk(rule)
       end
 
-      rule.issues.should be_empty
+      expect(rule.issues.size).to eq(0)
     end
   end
 
@@ -140,7 +140,7 @@ describe Preflight::Rules::NoSeparation do
         reader.page(2).walk(rule)
       end
 
-      rule.issues.should be_empty
+      expect(rule.issues.size).to eq(0)
     end
   end
 
@@ -154,7 +154,7 @@ describe Preflight::Rules::NoSeparation do
         reader.page(3).walk(rule)
       end
 
-      rule.issues.should be_empty
+      expect(rule.issues.size).to eq(0)
     end
   end
 
@@ -168,7 +168,7 @@ describe Preflight::Rules::NoSeparation do
         reader.page(4).walk(rule)
       end
 
-      rule.issues.should be_empty
+      expect(rule.issues.size).to eq(0)
     end
   end
 
@@ -182,7 +182,7 @@ describe Preflight::Rules::NoSeparation do
         reader.page(5).walk(rule)
       end
 
-      rule.issues.should be_empty
+      expect(rule.issues.size).to eq(0)
     end
   end
 
@@ -196,7 +196,7 @@ describe Preflight::Rules::NoSeparation do
         reader.page(6).walk(rule)
       end
 
-      rule.issues.should be_empty
+      expect(rule.issues.size).to eq(0)
     end
   end
 

--- a/spec/rules/no_transparency_spec.rb
+++ b/spec/rules/no_transparency_spec.rb
@@ -11,15 +11,15 @@ describe Preflight::Rules::NoTransparency do
       PDF::Reader.open(filename) do |reader|
         reader.page(2).walk(rule)
 
-        rule.issues.should have(1).item
+        expect(rule.issues.size).to eq(1)
 
         issue = rule.issues.first
-        issue.rule.should         == :"Preflight::Rules::NoTransparency"
-        issue.page.should         == 2
-        issue.top_left.should     == [99.0, 540.89]
-        issue.bottom_left.should  == [99.0, 742.89]
-        issue.bottom_right.should == [301.0, 742.89]
-        issue.top_right.should    == [301.0, 540.89]
+        expect(issue.rule).to eq(:"Preflight::Rules::NoTransparency")
+        expect(issue.page).to eq(2)
+        expect(issue.top_left).to eq([99.0, 540.89])
+        expect(issue.bottom_left).to eq([99.0, 742.89])
+        expect(issue.bottom_right).to eq([301.0, 742.89])
+        expect(issue.top_right).to eq([301.0, 540.89])
       end
     end
   end
@@ -32,7 +32,7 @@ describe Preflight::Rules::NoTransparency do
 
       PDF::Reader.open(filename) do |reader|
         reader.page(1).walk(rule)
-        rule.issues.should be_empty
+        expect(rule.issues).to be_empty
       end
     end
   end

--- a/spec/rules/only_embedded_fonts_spec.rb
+++ b/spec/rules/only_embedded_fonts_spec.rb
@@ -8,7 +8,7 @@ describe Preflight::Rules::OnlyEmbeddedFonts do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should be_empty
+      expect(rule.issues).to be_empty
     end
   end
 
@@ -18,7 +18,7 @@ describe Preflight::Rules::OnlyEmbeddedFonts do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should be_empty
+      expect(rule.issues).to be_empty
     end
   end
 
@@ -32,7 +32,7 @@ describe Preflight::Rules::OnlyEmbeddedFonts do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should_not be_empty
+      expect(rule.issues).to_not be_empty
     end
   end
 end

--- a/spec/rules/output_intent_for_pdfx_spec.rb
+++ b/spec/rules/output_intent_for_pdfx_spec.rb
@@ -7,7 +7,7 @@ describe Preflight::Rules::OutputIntentForPdfx do
     ohash    = PDF::Reader::ObjectHash.new(filename)
     chk      = Preflight::Rules::OutputIntentForPdfx.new
 
-    chk.check_hash(ohash).should_not be_empty
+    expect(chk.check_hash(ohash)).to_not be_empty
   end
 
   it "pass files with a single OutputIntent for PDF/X" do
@@ -15,7 +15,7 @@ describe Preflight::Rules::OutputIntentForPdfx do
     ohash    = PDF::Reader::ObjectHash.new(filename)
     chk      = Preflight::Rules::DocumentId.new
 
-    chk.check_hash(ohash).should be_empty
+    expect(chk.check_hash(ohash)).to be_empty
   end
 
 end

--- a/spec/rules/page_box_height_spec.rb
+++ b/spec/rules/page_box_height_spec.rb
@@ -8,7 +8,7 @@ describe Preflight::Rules::PageBoxHeight do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should be_empty
+      expect(rule.issues).to be_empty
     end
   end
 
@@ -18,7 +18,7 @@ describe Preflight::Rules::PageBoxHeight do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should be_empty
+      expect(rule.issues).to be_empty
     end
   end
 
@@ -28,7 +28,7 @@ describe Preflight::Rules::PageBoxHeight do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should_not be_empty
+      expect(rule.issues).to_not be_empty
     end
   end
 
@@ -38,7 +38,7 @@ describe Preflight::Rules::PageBoxHeight do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should_not be_empty
+      expect(rule.issues).to_not be_empty
     end
   end
 
@@ -49,7 +49,7 @@ describe Preflight::Rules::PageBoxHeight do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should be_empty
+      expect(rule.issues).to be_empty
     end
   end
 
@@ -59,7 +59,7 @@ describe Preflight::Rules::PageBoxHeight do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should be_empty
+      expect(rule.issues).to be_empty
     end
   end
 
@@ -69,7 +69,7 @@ describe Preflight::Rules::PageBoxHeight do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should_not be_empty
+      expect(rule.issues).to_not be_empty
     end
   end
 
@@ -79,7 +79,7 @@ describe Preflight::Rules::PageBoxHeight do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should_not be_empty
+      expect(rule.issues).to_not be_empty
     end
   end
 
@@ -91,7 +91,7 @@ describe Preflight::Rules::PageBoxHeight do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should be_empty
+      expect(rule.issues).to be_empty
     end
   end
 
@@ -101,7 +101,7 @@ describe Preflight::Rules::PageBoxHeight do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should be_empty
+      expect(rule.issues).to be_empty
     end
   end
 
@@ -111,7 +111,7 @@ describe Preflight::Rules::PageBoxHeight do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should_not be_empty
+      expect(rule.issues).to_not be_empty
     end
   end
 
@@ -121,7 +121,7 @@ describe Preflight::Rules::PageBoxHeight do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should_not be_empty
+      expect(rule.issues).to_not be_empty
     end
   end
 end

--- a/spec/rules/page_box_size_spec.rb
+++ b/spec/rules/page_box_size_spec.rb
@@ -11,7 +11,7 @@ describe Preflight::Rules::PageBoxSize do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should be_empty
+      expect(rule.issues).to be_empty
     end
   end
 
@@ -24,7 +24,7 @@ describe Preflight::Rules::PageBoxSize do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should be_empty
+      expect(rule.issues).to be_empty
     end
   end
 
@@ -37,7 +37,7 @@ describe Preflight::Rules::PageBoxSize do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should_not be_empty
+      expect(rule.issues).to_not be_empty
     end
   end
 
@@ -50,7 +50,7 @@ describe Preflight::Rules::PageBoxSize do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should_not be_empty
+      expect(rule.issues).to_not be_empty
     end
   end
 
@@ -63,7 +63,7 @@ describe Preflight::Rules::PageBoxSize do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should be_empty
+      expect(rule.issues).to be_empty
     end
   end
 
@@ -76,7 +76,7 @@ describe Preflight::Rules::PageBoxSize do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should be_empty
+      expect(rule.issues).to be_empty
     end
   end
 
@@ -89,7 +89,7 @@ describe Preflight::Rules::PageBoxSize do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should_not be_empty
+      expect(rule.issues).to_not be_empty
     end
   end
 
@@ -102,7 +102,7 @@ describe Preflight::Rules::PageBoxSize do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should_not be_empty
+      expect(rule.issues).to_not be_empty
     end
   end
 
@@ -115,20 +115,20 @@ describe Preflight::Rules::PageBoxSize do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should be_empty
+      expect(rule.issues).to be_empty
     end
   end
 
   it "should pass files with a box that isn't present" do
     filename = pdf_spec_file("pdfx-1a-subsetting")
     rule     = Preflight::Rules::PageBoxSize.new(:ArtBox,
-                                                 :width => 10, 
-                                                 :height => 10, 
+                                                 :width => 10,
+                                                 :height => 10,
                                                  :units => :mm)
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should be_empty
+      expect(rule.issues).to be_empty
     end
   end
 

--- a/spec/rules/page_box_width_spec.rb
+++ b/spec/rules/page_box_width_spec.rb
@@ -8,7 +8,7 @@ describe Preflight::Rules::PageBoxWidth do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should be_empty
+      expect(rule.issues).to be_empty
     end
   end
 
@@ -18,7 +18,7 @@ describe Preflight::Rules::PageBoxWidth do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should be_empty
+      expect(rule.issues).to be_empty
     end
   end
 
@@ -28,7 +28,7 @@ describe Preflight::Rules::PageBoxWidth do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should_not be_empty
+      expect(rule.issues).to_not be_empty
     end
   end
 
@@ -38,7 +38,7 @@ describe Preflight::Rules::PageBoxWidth do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should_not be_empty
+      expect(rule.issues).to_not be_empty
     end
   end
 
@@ -49,7 +49,7 @@ describe Preflight::Rules::PageBoxWidth do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should be_empty
+      expect(rule.issues).to be_empty
     end
   end
 
@@ -59,7 +59,7 @@ describe Preflight::Rules::PageBoxWidth do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should be_empty
+      expect(rule.issues).to be_empty
     end
   end
 
@@ -69,7 +69,7 @@ describe Preflight::Rules::PageBoxWidth do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should_not be_empty
+      expect(rule.issues).to_not be_empty
     end
   end
 
@@ -79,7 +79,7 @@ describe Preflight::Rules::PageBoxWidth do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should_not be_empty
+      expect(rule.issues).to_not be_empty
     end
   end
 
@@ -91,7 +91,7 @@ describe Preflight::Rules::PageBoxWidth do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should be_empty
+      expect(rule.issues).to be_empty
     end
   end
 
@@ -101,7 +101,7 @@ describe Preflight::Rules::PageBoxWidth do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should be_empty
+      expect(rule.issues).to be_empty
     end
   end
 
@@ -111,7 +111,7 @@ describe Preflight::Rules::PageBoxWidth do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should_not be_empty
+      expect(rule.issues).to_not be_empty
     end
   end
 
@@ -121,7 +121,7 @@ describe Preflight::Rules::PageBoxWidth do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should_not be_empty
+      expect(rule.issues).to_not be_empty
     end
   end
 end

--- a/spec/rules/page_count_spec.rb
+++ b/spec/rules/page_count_spec.rb
@@ -7,7 +7,7 @@ describe Preflight::Rules::PageCount do
     ohash    = PDF::Reader::ObjectHash.new(filename)
     rule     = Preflight::Rules::PageCount.new(1)
 
-    rule.check_hash(ohash).should be_empty
+    expect(rule.check_hash(ohash)).to be_empty
   end
 
   it "should fail files with incorrect page count specified by Fixnum" do
@@ -15,7 +15,7 @@ describe Preflight::Rules::PageCount do
     ohash    = PDF::Reader::ObjectHash.new(filename)
     rule     = Preflight::Rules::PageCount.new(2)
 
-    rule.check_hash(ohash).should_not be_empty
+    expect(rule.check_hash(ohash)).to_not be_empty
   end
 
   it "should pass files with correct page count specified by range" do
@@ -23,7 +23,7 @@ describe Preflight::Rules::PageCount do
     ohash    = PDF::Reader::ObjectHash.new(filename)
     rule     = Preflight::Rules::PageCount.new(1..2)
 
-    rule.check_hash(ohash).should be_empty
+    expect(rule.check_hash(ohash)).to be_empty
   end
 
   it "should fail files with incorrect page count specified by range" do
@@ -31,7 +31,7 @@ describe Preflight::Rules::PageCount do
     ohash    = PDF::Reader::ObjectHash.new(filename)
     rule     = Preflight::Rules::PageCount.new(2..3)
 
-    rule.check_hash(ohash).should_not be_empty
+    expect(rule.check_hash(ohash)).to_not be_empty
   end
 
   it "should pass files with correct page count specified by array" do
@@ -39,7 +39,7 @@ describe Preflight::Rules::PageCount do
     ohash    = PDF::Reader::ObjectHash.new(filename)
     rule     = Preflight::Rules::PageCount.new([1, 2])
 
-    rule.check_hash(ohash).should be_empty
+    expect(rule.check_hash(ohash)).to be_empty
   end
 
   it "should fail files with incorrect page count specified by array" do
@@ -47,7 +47,7 @@ describe Preflight::Rules::PageCount do
     ohash    = PDF::Reader::ObjectHash.new(filename)
     rule     = Preflight::Rules::PageCount.new([2, 3])
 
-    rule.check_hash(ohash).should_not be_empty
+    expect(rule.check_hash(ohash)).to_not be_empty
   end
 
   it "should pass files with correct page count specified by :odd" do
@@ -55,7 +55,7 @@ describe Preflight::Rules::PageCount do
     ohash    = PDF::Reader::ObjectHash.new(filename)
     rule     = Preflight::Rules::PageCount.new(:odd)
 
-    rule.check_hash(ohash).should be_empty
+    expect(rule.check_hash(ohash)).to be_empty
   end
 
   it "should fail files with correct page count specified by :odd" do
@@ -63,7 +63,7 @@ describe Preflight::Rules::PageCount do
     ohash    = PDF::Reader::ObjectHash.new(filename)
     rule     = Preflight::Rules::PageCount.new(:odd)
 
-    rule.check_hash(ohash).should_not be_empty
+    expect(rule.check_hash(ohash)).to_not be_empty
   end
 
   it "should pass files with correct page count specified by :even" do
@@ -71,7 +71,7 @@ describe Preflight::Rules::PageCount do
     ohash    = PDF::Reader::ObjectHash.new(filename)
     rule     = Preflight::Rules::PageCount.new(:even)
 
-    rule.check_hash(ohash).should be_empty
+    expect(rule.check_hash(ohash)).to be_empty
   end
 
   it "should fail files with correct page count specified by :even" do
@@ -79,7 +79,7 @@ describe Preflight::Rules::PageCount do
     ohash    = PDF::Reader::ObjectHash.new(filename)
     rule     = Preflight::Rules::PageCount.new(:even)
 
-    rule.check_hash(ohash).should_not be_empty
+    expect(rule.check_hash(ohash)).to_not be_empty
   end
 
 end

--- a/spec/rules/print_boxes_spec.rb
+++ b/spec/rules/print_boxes_spec.rb
@@ -8,7 +8,7 @@ describe Preflight::Rules::PrintBoxes do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should be_empty
+      expect(rule.issues).to be_empty
     end
   end
 
@@ -18,7 +18,7 @@ describe Preflight::Rules::PrintBoxes do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should be_empty
+      expect(rule.issues).to be_empty
     end
   end
 
@@ -28,7 +28,7 @@ describe Preflight::Rules::PrintBoxes do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should_not be_empty
+      expect(rule.issues).to_not be_empty
     end
   end
 
@@ -38,7 +38,7 @@ describe Preflight::Rules::PrintBoxes do
 
     PDF::Reader.open(filename) do |reader|
       reader.page(1).walk(rule)
-      rule.issues.should_not be_empty
+      expect(rule.issues).to_not be_empty
     end
   end
 

--- a/spec/rules/root_has_keys_spec.rb
+++ b/spec/rules/root_has_keys_spec.rb
@@ -7,7 +7,7 @@ describe Preflight::Rules::RootHasKeys do
     ohash    = PDF::Reader::ObjectHash.new(filename)
     chk      = Preflight::Rules::RootHasKeys.new(:OutputIntents)
 
-    chk.check_hash(ohash).should_not be_empty
+    expect(chk.check_hash(ohash)).to_not be_empty
   end
 
   it "pass files with no GTS_PDFXVersion entry in the Info dict" do
@@ -15,7 +15,7 @@ describe Preflight::Rules::RootHasKeys do
     ohash    = PDF::Reader::ObjectHash.new(filename)
     chk      = Preflight::Rules::RootHasKeys.new(:OutputIntents)
 
-    chk.check_hash(ohash).should be_empty
+    expect(chk.check_hash(ohash)).to be_empty
   end
 
 end


### PR DESCRIPTION
## Description of the change

> make pdf-preflight compatible with ruby 3.4 and rubygems 4.x 
- updated minimum rails version (2.5+) add gems for matrix and BigDecimal (no longer in std lib), removed rdoc (not compatible with rubygems 4.x), updated rspec (compatible with ruby 3.x) and modernize spec syntax

## Type of change
- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## Related issues

> Fix [#1]() 

## Checklists

### Development

- [ ] Lint rules pass locally
- [ ] The code changed/added as part of this pull request has been covered with tests
- [ ] All tests related to the changed code pass in development

### Code review 

- [ ]  This pull request has a descriptive title and information useful to a reviewer. There may be a screenshot or screencast attached
- [ ] "Ready for review" label attached to the PR and reviewers mentioned in a comment
- [ ] Changes have been reviewed by at least one other engineer
- [ ] Issue from task tracker has a link to this pull request 
